### PR TITLE
Change LoadButton callback to binded function

### DIFF
--- a/src/states/UkeireQuiz.js
+++ b/src/states/UkeireQuiz.js
@@ -535,7 +535,7 @@ class UkeireQuiz extends React.Component {
                         <Button className="btn-block" color={this.state.isComplete ? "success" : "warning"} onClick={() => this.onNewHand()}>{t("trainer.newHandButtonLabel")}</Button>
                     </Col>
                     <CopyButton hand={this.state.hand} />
-                    <LoadButton callback={this.onHandLoaded} />
+                    <LoadButton callback={this.loadHand} />
                 </Row>
                 <Row className="mt-2 no-gutters">
                     <History history={this.state.history} concise={this.state.settings.extraConcise} verbose={this.state.settings.verbose} spoilers={this.state.settings.spoilers}/>


### PR DESCRIPTION
Got mistakenly changed during a renaming change earlier, which caused the `let remainingTiles = this.getStartingTiles();` in `onHandLoaded` to fail.