### PR TITLE
[PATCH] Add defense timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.<br>
 You will also see any lint errors in the console.
 
+If you run into `ERR_OSSL_EVP_UNSUPPORTED`, you may need to `export NODE_OPTIONS=--openssl-legacy-provider` to get it working.
+
 ### `npm run build`
 
 Builds the app for production to the `build` folder.<br>

--- a/src/components/defense-trainer/DefenseSettings.js
+++ b/src/components/defense-trainer/DefenseSettings.js
@@ -15,6 +15,9 @@ class Settings extends React.Component {
                 numberOfRiichis: 1,
                 minimumTurnsBeforeRiichi: 5,
                 tilesInHand: 13,
+                useTimer: false,
+                time: 5,
+                extraTime: 10,
             }
         };
 
@@ -37,6 +40,9 @@ class Settings extends React.Component {
                     numberOfRiichis: savedSettings.numberOfRiichis || 1,
                     minimumTurnsBeforeRiichi: savedSettings.minimumTurnsBeforeRiichi || 4,
                     tilesInHand: savedSettings.tilesInHand || 13,
+                    useTimer: savedSettings.useTimer,
+                    time: savedSettings.time || 5,
+                    extraTime: savedSettings.extraTime === undefined ? 10 : savedSettings.extraTime
                 }
 
                 this.setState({
@@ -118,6 +124,31 @@ class Settings extends React.Component {
                                 <NumericInput className="form-check-input" type="number" id="tilesInHand"
                                     min={2} max={14} step={3}
                                     value={this.state.settings.tilesInHand} onChange={this.onSettingChanged} />
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col className="form-check form-check-inline">
+                                <Input className="form-check-input" type="checkbox" id="useTimer"
+                                    checked={this.state.settings.useTimer} onChange={this.onSettingChanged} />
+                                <Label className="form-check-label" for="useTimer">{t("settings.useTimer")}</Label>
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col className="form-check form-check-inline">
+                                <Label className="form-check-label" for="time">{t("settings.time")}&nbsp;</Label>
+                                <NumericInput className="form-check-input" type="number" id="time"
+                                    min={1} max={99} step={1}
+                                    value={this.state.settings.time} onChange={this.onSettingChanged} />
+                                <span className="blackText">&nbsp;{t("settings.seconds")}</span>
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col className="form-check form-check-inline">
+                                <Label className="form-check-label" for="time">{t("settings.extraTime")}&nbsp;</Label>
+                                <NumericInput className="form-check-input" type="number" id="extraTime"
+                                    min={0} max={99} step={1}
+                                    value={this.state.settings.extraTime} onChange={this.onSettingChanged} />
+                                <span className="blackText">&nbsp;{t("settings.seconds")}</span>
                             </Col>
                         </Row>
                     </CardBody></Card>

--- a/src/states/DefenseState.js
+++ b/src/states/DefenseState.js
@@ -65,6 +65,17 @@ class DefenseState extends React.Component {
                 clearTimeout(this.timer);
                 clearInterval(this.timerUpdate);
             }
+        } else {
+            this.timer = setTimeout(
+                () => {
+                    this.onTileClicked({target:{name:this.state.lastDraw}});
+                    this.setState({
+                        currentBonus: 0
+                    });
+                },
+                (this.state.settings.time + this.state.settings.extraTime + 2) * 1000
+            );
+            this.timerUpdate = setInterval(this.updateTime, 100);
         }
 
         this.setState({

--- a/src/states/DefenseState.js
+++ b/src/states/DefenseState.js
@@ -23,6 +23,9 @@ class DefenseState extends React.Component {
         super(props);
         this.onTileClicked = this.onTileClicked.bind(this);
         this.onSettingsChanged = this.onSettingsChanged.bind(this);
+        this.updateTime = this.onUpdateTime.bind(this);
+        this.timerUpdate = null;
+        this.timer = null;
         this.state = {
             lastDraw: 0,
             isComplete: false,
@@ -38,7 +41,9 @@ class DefenseState extends React.Component {
                 numberOfRiichis: 1,
                 minimumTurnsBeforeRiichi: 4,
                 tilesInHand: 13,
-            }
+            },
+            currentTime: 0,
+            currentBonus: 0,
         }
     }
 
@@ -47,7 +52,21 @@ class DefenseState extends React.Component {
         this.setState({}, () => this.onNewHand());
     }
 
+    componentWillUnmount() {
+        if (this.timer != null) {
+            clearTimeout(this.timer);
+            clearInterval(this.timerUpdate);
+        }
+    }
+
     onSettingsChanged(settings) {
+        if (!settings.useTimer) {
+            if (this.timer != null) {
+                clearTimeout(this.timer);
+                clearInterval(this.timerUpdate);
+            }
+        }
+
         this.setState({
             settings: settings
         });
@@ -55,6 +74,11 @@ class DefenseState extends React.Component {
 
     /** Generates a fresh game state. */
     onNewHand() {
+        if (this.timer != null) {
+            clearTimeout(this.timer);
+            clearInterval(this.timerUpdate);
+        }
+
         /** @type {Player[]} */
         let players = [];
         let tilePool = [];
@@ -202,15 +226,33 @@ class DefenseState extends React.Component {
             removeRandomItem(tilePool);
         }
 
+        let shuffle = convertHandToTileIndexArray(players[0].hand);
+        shuffle = shuffleArray(shuffle);
+
         this.setState({
             players: players,
             tilePool: tilePool,
             history: [new HistoryData(new LocalizedMessage("trainer.start", { hand: convertHandToTenhouString(players[0].hand) }))],
             discardCount: 0,
             dora: dora,
-            lastDraw: -1,
-            isComplete: false
+            lastDraw: shuffle.pop(),
+            isComplete: false,
+            currentTime: this.state.settings.time + 2,
+            currentBonus: this.state.settings.extraTime
         });
+
+        if (this.state.settings.useTimer) {
+            this.timer = setTimeout(
+                () => {
+                    this.onTileClicked({target:{name:this.state.lastDraw}});
+                    this.setState({
+                        currentBonus: 0
+                    });
+                },
+                (this.state.settings.time + this.state.settings.extraTime + 2) * 1000
+            );
+            this.timerUpdate = setInterval(this.updateTime, 100);
+        }
     }
 
     /**
@@ -370,6 +412,11 @@ class DefenseState extends React.Component {
     }
 
     onTileClicked(event) {
+        if (this.timer != null) {
+            clearTimeout(this.timer);
+            clearInterval(this.timerUpdate);
+        }
+
         let { t } = this.props;
         let isComplete = this.state.isComplete;
         if (isComplete) return;
@@ -416,6 +463,17 @@ class DefenseState extends React.Component {
         } else {
             draw = removeRandomItem(tilePool);
             players[0].hand[draw]++;
+
+            this.timer = setTimeout(
+                () => {
+                    this.onTileClicked({target:{name:this.state.lastDraw}});
+                    this.setState({
+                        currentBonus: 0
+                    });
+                },
+                (this.state.settings.time + this.state.currentBonus) * 1000
+            );
+            this.timerUpdate = setInterval(this.updateTime, 100);
         }
 
         let bestSafety = Math.max(...averageSafety);
@@ -435,8 +493,21 @@ class DefenseState extends React.Component {
             discardCount: this.state.discardCount + 1,
             lastDraw: draw,
             history: history,
-            isComplete: isComplete
+            isComplete: isComplete,
+            currentTime: this.state.settings.time,
         });
+    }
+
+    onUpdateTime() {
+        if (this.state.currentTime > 0.1) {
+            this.setState({
+                currentTime: Math.max(this.state.currentTime - 0.1, 0)
+            });
+        } else {
+            this.setState({
+                currentBonus: Math.max(this.state.currentBonus - 0.1, 0)
+            });
+        }
     }
 
     /**
@@ -492,6 +563,10 @@ class DefenseState extends React.Component {
                                 <Button className="btn-block" color={this.state.isComplete ? "success" : "warning"} onClick={() => this.onNewHand()}>{t("trainer.newHandButtonLabel")}</Button>
                             </Col>
                         </Row>
+                        {this.state.settings.useTimer ?
+                        <Row className="mt-2" style={{justifyContent:'flex-end', marginRight:1}}><span>{this.state.currentTime.toFixed(1)} + {this.state.currentBonus.toFixed(1)}</span></Row>
+                            : ""
+                        }
                         <Row className="mt-2 no-gutters">
                             <History history={this.state.history} concise={true} verbose={this.state.settings.verbose} spoilers={this.state.settings.spoilers} />
                             <DiscardPool players={this.state.players} discardCount={this.state.discardCount} wallCount={this.state.tilePool && this.state.tilePool.length} showIndexes={this.state.settings.showIndexes} />


### PR DESCRIPTION
👋 Hey! Thank you so much for making this efficiency tile trainer. I've been finding it super useful. As I was practicing _defense_, I realized that I was missing the urgency that comes from a trainer so I just ported over the one from the Trainer.

## How I Tested
Switch to "folding" tab.
- [x] When you already have the _timer_ enabled, it immediately starts (with a 2 second bonus, just like trainer).
- [x] If you don't, there's no timer visible. When you toggle it, it starts counting down.
- [x] If you let the time run out on the first hand, it discards the last drawn tile.
- [x] If you let the time run out on a subsequent hand, it discards the last drawn tile.
- [x] If you disable the timer while it's running, it disappears and stops discarding tiles.
- [x] When the hand is over, the timer stops running.
- [x] When you click "New Hand" after, the timer resets to the settings values with the 2 second buffer.