### PR TITLE
[PATCH] Add shanten calculator

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -78,3 +78,9 @@ export const TSUMO_SCORES = [
 export const PLACEMENTS = [
     "allLast.placements.fourth", "allLast.placements.third", "allLast.placements.second", "allLast.placements.first"
 ];
+
+export const CSS_CLASSES = {
+    INCORRECT: "bg-danger text-white",
+    CORRECT: "bg-success text-white",
+    WARNING: "bg-warning",
+};

--- a/src/components/shanten-quiz/Settings.js
+++ b/src/components/shanten-quiz/Settings.js
@@ -15,6 +15,7 @@ class Settings extends React.Component {
             settings: {
                 useTimer: false,
                 showIndexes: false,
+                showHandInHistory: false,
                 time: DEFAULT_TIME,
             }
         };
@@ -35,6 +36,7 @@ class Settings extends React.Component {
                 let settings = {
                     useTimer: savedSettings.useTimer,
                     showIndexes: savedSettings.showIndexes,
+                    showHandInHistory: savedSettings.showHandInHistory,
                     time: savedSettings.time || DEFAULT_TIME,
                 }
 
@@ -102,6 +104,13 @@ class Settings extends React.Component {
                                 <Input className="form-check-input" type="checkbox" id="showIndexes"
                                     checked={this.state.settings.showIndexes} onChange={this.onSettingChanged} />
                                 <Label className="form-check-label" for="showIndexes">{t("settings.showIndexes")}</Label>
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col className="form-check form-check-inline">
+                                <Input className="form-check-input" type="checkbox" id="showHandInHistory"
+                                    checked={this.state.settings.showHandInHistory} onChange={this.onSettingChanged} />
+                                <Label className="form-check-label" for="showHandInHistory">{t("settings.shanten.showHandInHistory")}</Label>
                             </Col>
                         </Row>
                     </CardBody></Card>

--- a/src/components/shanten-quiz/Settings.js
+++ b/src/components/shanten-quiz/Settings.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import { Container, Collapse, Card, CardBody, Button, Row, Col, Input, Label } from 'reactstrap';
+import NumericInput from 'react-numeric-input';
+import { withTranslation } from "react-i18next";
+
+const SETTINGS_KEY = "shantenSettings";
+const DEFAULT_TIME = 10;
+
+class Settings extends React.Component {
+    constructor(props) {
+        super(props);
+        this.toggle = this.toggle.bind(this);
+        this.state = {
+            collapsed: true,
+            settings: {
+                useTimer: false,
+                time: DEFAULT_TIME,
+            }
+        };
+
+        this.onSettingChanged = this.onSettingChanged.bind(this);
+    }
+
+    toggle() {
+        this.setState({ collapsed: !this.state.collapsed });
+    }
+
+    componentDidMount() {
+        try {
+            let savedSettings = window.localStorage.getItem(SETTINGS_KEY);
+            if (savedSettings) {
+                savedSettings = JSON.parse(savedSettings);
+
+                let settings = {
+                    useTimer: savedSettings.useTimer,
+                    time: savedSettings.time || DEFAULT_TIME,
+                }
+
+                this.setState({
+                    settings: settings
+                });
+
+                this.props.onChange(settings);
+            } else {
+                this.props.onChange(this.state.settings);
+            }
+        } catch {
+            this.props.onChange(this.state.settings);
+        }
+    }
+
+    onSettingChanged(event, numberString, numberInput) {
+        if (!event) return;
+
+        let settings = this.state.settings;
+
+        if (typeof event === "number") {
+            settings[numberInput.id] = event;
+        }
+        else {
+            settings[event.target.id] = !settings[event.target.id];
+        }
+
+        this.setState({
+            settings: settings
+        });
+
+        try {
+            window.localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+        } catch { }
+
+        this.props.onChange(settings);
+    }
+
+    render() {
+        const { t } = this.props;
+        return (
+            <Container>
+                <Button color="primary" onClick={this.toggle}>{t("settings.buttonLabel")}</Button>
+                <Collapse isOpen={!this.state.collapsed}>
+                    <Card><CardBody>
+                        <Row>
+                            <Col className="form-check form-check-inline">
+                                <Input className="form-check-input" type="checkbox" id="useTimer"
+                                    checked={this.state.settings.useTimer} onChange={this.onSettingChanged} />
+                                <Label className="form-check-label" for="useTimer">{t("settings.useTimer")}</Label>
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col className="form-check form-check-inline">
+                                <Label className="form-check-label" for="time">{t("settings.time")}&nbsp;</Label>
+                                <NumericInput className="form-check-input" type="number" id="time"
+                                    min={1} max={99} step={1}
+                                    value={this.state.settings.time} onChange={this.onSettingChanged} />
+                                <span className="blackText">&nbsp;{t("settings.seconds")}</span>
+                            </Col>
+                        </Row>
+                    </CardBody></Card>
+                </Collapse>
+            </Container>
+        );
+    }
+}
+
+export default withTranslation()(Settings);

--- a/src/components/shanten-quiz/Settings.js
+++ b/src/components/shanten-quiz/Settings.js
@@ -14,6 +14,7 @@ class Settings extends React.Component {
             collapsed: true,
             settings: {
                 useTimer: false,
+                showIndexes: false,
                 time: DEFAULT_TIME,
             }
         };
@@ -33,6 +34,7 @@ class Settings extends React.Component {
 
                 let settings = {
                     useTimer: savedSettings.useTimer,
+                    showIndexes: savedSettings.showIndexes,
                     time: savedSettings.time || DEFAULT_TIME,
                 }
 
@@ -93,6 +95,13 @@ class Settings extends React.Component {
                                     min={1} max={99} step={1}
                                     value={this.state.settings.time} onChange={this.onSettingChanged} />
                                 <span className="blackText">&nbsp;{t("settings.seconds")}</span>
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col className="form-check form-check-inline">
+                                <Input className="form-check-input" type="checkbox" id="showIndexes"
+                                    checked={this.state.settings.showIndexes} onChange={this.onSettingChanged} />
+                                <Label className="form-check-label" for="showIndexes">{t("settings.showIndexes")}</Label>
                             </Col>
                         </Row>
                     </CardBody></Card>

--- a/src/components/shanten-quiz/StatsDisplay.js
+++ b/src/components/shanten-quiz/StatsDisplay.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Container, Collapse, Card, CardBody, Button, Row, Col } from 'reactstrap';
+import { withTranslation } from 'react-i18next';
+
+class StatsDisplay extends React.Component {
+    constructor(props) {
+        super(props);
+        this.toggleStats = this.toggleStats.bind(this);
+        this.toggleConfirm = this.toggleConfirm.bind(this);
+        this.state = {
+            statsCollapsed: true,
+            confirmCollapsed: true
+        };
+    }
+
+    toggleStats() {
+        this.setState({ statsCollapsed: !this.state.statsCollapsed });
+    }
+
+    toggleConfirm() {
+        this.setState({ confirmCollapsed: !this.state.confirmCollapsed });
+    }
+
+    render() {
+        const { t, values, useTimer } = this.props;
+
+        let correctGuesses = values.correctGuesses || 0;
+        let totalGuesses = values.totalGuesses || 0;
+        let correctRate = totalGuesses > 0 ? (correctGuesses / totalGuesses) * 100 : 0;
+        correctRate = Math.round(correctRate);
+
+        let averageTime = values.totalTime / totalGuesses;
+        if (isNaN(averageTime)) averageTime = 0;
+        averageTime = Math.round(averageTime * 10) / 10;
+
+        return (
+            <Container>
+                <Button color="primary" onClick={this.toggleStats}>{t("shanten.stats.buttonLabel")}</Button>
+                <Collapse isOpen={!this.state.statsCollapsed}>
+                    <Card><CardBody>
+                        <Row>
+                            {t("shanten.stats.correctGuesses", { count: correctGuesses, total: totalGuesses, percent: correctRate })}
+                        </Row>
+                        {useTimer && <Row>
+                            {t("shanten.stats.averageTime", { time: averageTime })}
+                        </Row>}
+                        <Row className="mt-4">
+                            <Button color="danger" onClick={this.toggleConfirm}>{t("shanten.stats.reset")}</Button>
+                        </Row>
+                        <Row>
+                            <Collapse isOpen={!this.state.confirmCollapsed}>
+                                <Card><CardBody>
+                                    <Row>{t("shanten.stats.confirmation")}</Row>
+                                    <Row>
+                                        <Button color="danger" onClick={this.props.onReset}>{t("shanten.stats.yes")}</Button>
+                                        <Col xs="1" />
+                                        <Button color="success" onClick={this.toggleConfirm}>{t("shanten.stats.no")}</Button>
+                                    </Row>
+                                </CardBody></Card>
+                            </Collapse>
+                        </Row>
+                    </CardBody></Card>
+                </Collapse>
+            </Container>
+        );
+    }
+}
+
+export default withTranslation()(StatsDisplay);

--- a/src/components/ukeire-quiz/UkeireHistoryData.js
+++ b/src/components/ukeire-quiz/UkeireHistoryData.js
@@ -1,5 +1,6 @@
 import { getTileAsText } from "../../scripts/TileConversions";
 import HistoryData from "../../models/HistoryData";
+import { CSS_CLASSES } from "../../Constants";
 
 export default class UkeireHistoryData extends HistoryData {
     /** A history object for the ukeire trainer, which tells the efficiency of a given discard. */
@@ -71,13 +72,13 @@ export default class UkeireHistoryData extends HistoryData {
         let className = "";
 
         if (this.chosenUkeire.value <= 0 && this.shanten > 0) {
-            className = "bg-danger text-white";
+            className = CSS_CLASSES.INCORRECT;
         }
         else if (this.bestUkeire === this.chosenUkeire.value) {
-            className = "bg-success text-white";
+            className = CSS_CLASSES.CORRECT;
         }
         else {
-            className = "bg-warning";
+            className = CSS_CLASSES.WARNING;
         }
 
         return className;

--- a/src/states/MainMenu.js
+++ b/src/states/MainMenu.js
@@ -4,9 +4,20 @@ import UkeireQuiz from "./UkeireQuiz";
 import ReplayAnalysis from "./ReplayAnalysis";
 import UtilsState from "./UtilsState";
 import HandExplorer from "./HandExplorer";
+import Shanten from './Shanten';
 import SouthFourQuiz from './SouthFourQuiz';
 import { withTranslation } from "react-i18next";
 import DefenseState from './DefenseState';
+
+const STATES = {
+    UKEIRE: 0,
+    REPLAY: 1,
+    UTILS: 2,
+    EXPLORER: 3,
+    SOUTH_FOUR: 4,
+    DEFENSE: 5,
+    SHANTEN: 6,
+};
 
 class MainMenu extends React.Component {
     constructor(props) {
@@ -39,18 +50,20 @@ class MainMenu extends React.Component {
         let { t } = this.props;
         let page = <Row />;
         switch (this.state.active) {
-            case 0:
+            case STATES.UKEIRE:
                 page = <UkeireQuiz />; break;
-            case 1:
+            case STATES.REPLAY:
                 page = <ReplayAnalysis />; break;
-            case 2:
+            case STATES.UTILS:
                 page = <UtilsState />; break;
-            case 3:
+            case STATES.EXPLORER:
                 page = <HandExplorer />; break;
-            case 4:
+            case STATES.SOUTH_FOUR:
                 page = <SouthFourQuiz />; break;
-            case 5:
+            case STATES.DEFENSE:
                 page = <DefenseState />; break;
+            case STATES.SHANTEN:
+                page = <Shanten />; break;
             default:
                 page = <UkeireQuiz />;
         }
@@ -59,12 +72,13 @@ class MainMenu extends React.Component {
             <React.Fragment>
                 <Container className="mb-4">
                     <Row>
-                        <Button color="success" xs="4" disabled={this.state.active === 0} onClick={() => this.onSetActivePage(0)}>{t("menu.trainer")}</Button>
-                        <Button xs="4" disabled={this.state.active === 1} onClick={() => this.onSetActivePage(1)}>{t("menu.analyzer")}</Button>
-                        <Button xs="4" disabled={this.state.active === 4} onClick={() => this.onSetActivePage(4)}>{t("menu.allLast")}</Button>
-                        <Button xs="4" disabled={this.state.active === 5} onClick={() => this.onSetActivePage(5)}>{t("menu.defense")}</Button>
-                        <Button xs="4" disabled={this.state.active === 3} onClick={() => this.onSetActivePage(3)}>{t("menu.explorer")}</Button>
-                        <Button xs="4" disabled={this.state.active === 2} onClick={() => this.onSetActivePage(2)}>{t("menu.utils")}</Button>
+                        <Button color="success" xs="4" disabled={this.state.active === STATES.UKEIRE} onClick={() => this.onSetActivePage(STATES.UKEIRE)}>{t("menu.trainer")}</Button>
+                        <Button xs="4" disabled={this.state.active === STATES.REPLAY} onClick={() => this.onSetActivePage(STATES.REPLAY)}>{t("menu.analyzer")}</Button>
+                        <Button xs="4" disabled={this.state.active === STATES.SOUTH_FOUR} onClick={() => this.onSetActivePage(STATES.SOUTH_FOUR)}>{t("menu.allLast")}</Button>
+                        <Button xs="4" disabled={this.state.active === STATES.DEFENSE} onClick={() => this.onSetActivePage(STATES.DEFENSE)}>{t("menu.defense")}</Button>
+                        <Button xs="4" disabled={this.state.active === STATES.EXPLORER} onClick={() => this.onSetActivePage(STATES.EXPLORER)}>{t("menu.explorer")}</Button>
+                        <Button xs="4" disabled={this.state.active === STATES.SHANTEN} onClick={() => this.onSetActivePage(STATES.SHANTEN)}>{t("menu.shanten")}</Button>
+                        <Button xs="4" disabled={this.state.active === STATES.UTILS} onClick={() => this.onSetActivePage(STATES.UTILS)}>{t("menu.utils")}</Button>
                     </Row>
                     <Row>
                         <Dropdown isOpen={this.state.dropdownOpen} toggle={() => this.toggleDropdown()}>

--- a/src/states/Shanten.js
+++ b/src/states/Shanten.js
@@ -1,20 +1,24 @@
 import React from 'react';
-import { Container, Row, Button, Col } from 'reactstrap';
+import { Container, Row, Button, Col, Input, InputGroup, InputGroupAddon, ListGroup, ListGroupItem, ListGroupItemHeading } from 'reactstrap';
 import Hand from '../components/Hand';
 import { generateHand } from '../scripts/GenerateHand';
 import { calculateMinimumShanten } from "../scripts/ShantenCalculator";
 import { convertHandToTileIndexArray } from "../scripts/HandConversions";
 import { shuffleArray } from '../scripts/Utils';
 import { withTranslation } from 'react-i18next';
+import { CSS_CLASSES  } from '../Constants';
 
 class ShantenQuiz extends React.Component {
     constructor(props) {
         super(props);
         this.onNewHand = this.onNewHand.bind(this);
+        this.onSubmitGuess = this.onSubmitGuess.bind(this);
         this.state = {
             hand: null,
             shanten: null,
             shuffle: [],
+            guess: '',
+            history: [],
         };
     }
 
@@ -37,6 +41,7 @@ class ShantenQuiz extends React.Component {
             hand: hand,
             shanten: shanten,
             shuffle: shuffle,
+            guess: '',
         });
     }
 
@@ -58,6 +63,16 @@ class ShantenQuiz extends React.Component {
         return availableTiles;
     }
 
+    /** Handles the user's guess submission. */
+    onSubmitGuess() {
+        let { guess, shanten, history } = this.state;
+
+        const className = parseInt(guess) === shanten ? CSS_CLASSES.CORRECT : CSS_CLASSES.INCORRECT;
+        history.unshift({ text: `You guessed ${guess} shanten. It was ${shanten}.`, className });
+        this.setState({ history });
+        this.onNewHand();
+    }
+
     render() {
         let { t } = this.props;
 
@@ -69,12 +84,25 @@ class ShantenQuiz extends React.Component {
                 <Hand tiles={this.state.hand} showIndexes={true} />
                 <Row className="mt-2">
                     <Col xs="6" sm="3" md="3" lg="2">
-                        <Button className="btn-block" color="warning" onClick={this.onNewHand}>{t("trainer.newHandButtonLabel")}</Button>
+                        <Button className="btn-block" color="warning" onClick={() => this.onNewHand()}>{t("shanten.newHandButtonLabel")}</Button>
                     </Col>
                 </Row>
                 <Row className="mt-2">
-                    <span>{t("shanten.shantenLabel")} {this.state.shanten}</span>
+                    <Col xs="12" sm="8" md="6">
+                        <InputGroup>
+                            <Input type="number" value={this.state.guess} placeholder={t("shanten.guessPlaceholder")} onChange={(e) => this.setState({ guess: e.target.value })} />
+                            <InputGroupAddon addonType="append">
+                                <Button color="primary" onClick={this.onSubmitGuess}>{t("shanten.submitGuessButtonLabel")}</Button>
+                            </InputGroupAddon>
+                        </InputGroup>
+                    </Col>
                 </Row>
+                <ListGroup className="mt-2">
+                    <ListGroupItemHeading><span>{t("shanten.historyLabel")}</span></ListGroupItemHeading>
+                    {this.state.history.map((entry, index) => (
+                        <ListGroupItem key={index} className={entry.className}>{entry.text}</ListGroupItem>
+                    ))}
+                </ListGroup>
             </Container>
         );
     }

--- a/src/states/Shanten.js
+++ b/src/states/Shanten.js
@@ -1,10 +1,82 @@
 import React from 'react';
+import { Container, Row, Button, Col } from 'reactstrap';
+import Hand from '../components/Hand';
+import { generateHand } from '../scripts/GenerateHand';
+import { calculateMinimumShanten } from "../scripts/ShantenCalculator";
+import { convertHandToTileIndexArray } from "../scripts/HandConversions";
+import { shuffleArray } from '../scripts/Utils';
 import { withTranslation } from 'react-i18next';
 
 class ShantenQuiz extends React.Component {
-    render() {
+    constructor(props) {
+        super(props);
+        this.onNewHand = this.onNewHand.bind(this);
+        this.state = {
+            hand: null,
+            shanten: null,
+            shuffle: [],
+        };
+    }
 
-        return 'placeholder';
+    componentDidMount() {
+        this.onNewHand();
+    }
+
+    /** Generates a new hand and calculates its shanten. */
+    onNewHand() {
+        let remainingTiles = this.getStartingTiles();
+        let generationResult = generateHand(remainingTiles);
+        let hand = generationResult.hand;
+
+        let shanten = calculateMinimumShanten(hand);
+
+        let shuffle = convertHandToTileIndexArray(hand);
+        shuffle = shuffleArray(shuffle);
+
+        this.setState({
+            hand: hand,
+            shanten: shanten,
+            shuffle: shuffle,
+        });
+    }
+
+    /**
+     * Creates an array containing how many of each tile should be in the wall at the start of the game.
+     * @returns {TileCounts} The available tiles.
+     */
+    getStartingTiles() {
+        let availableTiles = Array(38).fill(0);
+
+        for (let i = 1; i < 30; i++) {
+            availableTiles[i] = 4;
+        }
+
+        for (let i = 31; i < 38; i++) {
+            availableTiles[i] = 4;
+        }
+
+        return availableTiles;
+    }
+
+    render() {
+        let { t } = this.props;
+
+        return (
+            <Container>
+                <Row className="mb-2 mt-2">
+                    <span>{t("shanten.instructions")}</span>
+                </Row>
+                <Hand tiles={this.state.hand} showIndexes={true} />
+                <Row className="mt-2">
+                    <Col xs="6" sm="3" md="3" lg="2">
+                        <Button className="btn-block" color="warning" onClick={this.onNewHand}>{t("trainer.newHandButtonLabel")}</Button>
+                    </Col>
+                </Row>
+                <Row className="mt-2">
+                    <span>{t("shanten.shantenLabel")} {this.state.shanten}</span>
+                </Row>
+            </Container>
+        );
     }
 }
 

--- a/src/states/Shanten.js
+++ b/src/states/Shanten.js
@@ -148,7 +148,7 @@ class ShantenQuiz extends React.Component {
                 <Row className="mb-2 mt-2">
                     <span>{t("shanten.instructions")}</span>
                 </Row>
-                <Hand tiles={this.state.hand} showIndexes={true} />
+                <Hand tiles={this.state.hand} showIndexes={this.state.settings.showIndexes} />
                 <Row className="mt-2">
                     <Col xs="6" sm="3" md="3" lg="2">
                         <Button className="btn-block" color="warning" onClick={() => this.onNewHand()}>{t("shanten.newHandButtonLabel")}</Button>

--- a/src/states/Shanten.js
+++ b/src/states/Shanten.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { withTranslation } from 'react-i18next';
+
+class ShantenQuiz extends React.Component {
+    render() {
+
+        return 'placeholder';
+    }
+}
+
+export default withTranslation()(ShantenQuiz);

--- a/src/states/Shanten.js
+++ b/src/states/Shanten.js
@@ -27,6 +27,8 @@ class ShantenQuiz extends React.Component {
             history: [],
             settings: {
                 useTimer: false,
+                showIndexes: false,
+                showHandInHistory: false,
                 time: 10,
             },
             currentTime: 0,
@@ -129,10 +131,10 @@ class ShantenQuiz extends React.Component {
 
     /** Handles the user's guess submission. */
     onSubmitGuess() {
-        let { guess, shanten, history, stats, currentTime } = this.state;
+        let { guess, shanten, hand, history, stats, currentTime } = this.state;
         const className = this.getHistoryClassName(guess, shanten);
         const text = this.getHistoryMessage(guess, shanten);
-        history.unshift({ text, className });
+        history.unshift({ text, className, hand });
 
         stats.totalGuesses += 1;
 
@@ -198,9 +200,12 @@ class ShantenQuiz extends React.Component {
                     : ""
                 }
                 <ListGroup className="mt-2">
-                    <ListGroupItemHeading><span>{t("shanten.historyLabel")}</span></ListGroupItemHeading>
+                    <ListGroupItemHeading><span>{t("shanten.history.buttonLabel")}</span></ListGroupItemHeading>
                     {this.state.history.map((entry, index) => (
-                        <ListGroupItem key={index} className={entry.className}>{entry.text}</ListGroupItem>
+                        <ListGroupItem key={index} className={entry.className}>
+                            {entry.text}
+                            {this.state.settings.showHandInHistory && <Hand tiles={entry.hand} showIndexes={this.state.settings.showIndexes} />}
+                        </ListGroupItem>
                     ))}
                 </ListGroup>
             </Container>

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -119,7 +119,10 @@ export const en = {
             useTimer: "Use timer",
             time: "Time per discard:",
             extraTime: "Bonus time per hand:",
-            seconds: "seconds"
+            seconds: "seconds",
+            shanten: {
+                showHandInHistory: "Show Hand in History"
+            }
         },
         stats: {
             buttonLabel: "Statistics",
@@ -290,7 +293,9 @@ export const en = {
             "newHandButtonLabel": "New Hand",
             "guessPlaceholder": "Your guess",
             "submitGuessButtonLabel": "Submit Guess",
-            historyLabel: "History",
+            history: {
+                buttonLabel: "History",
+            },
             stats: {
                 buttonLabel: "Statistics",
                 correctGuesses: "Correct Guesses: {{count}} / {{total}} ({{percent}}%)",

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -159,7 +159,8 @@ export const en = {
             explorer: "Explorer",
             utils: "Misc. Utils",
             language: "Language",
-            defense: "Folding"
+            defense: "Folding",
+            shanten: "Shanten"
         },
         allLast: {
             placements: {

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -287,7 +287,10 @@ export const en = {
         },
         shanten: {
             instructions: "Looking to improve your speed at calculating shanten? This tool will help you practice.",
-            shantenLabel: "Shanten:"
+            "newHandButtonLabel": "New Hand",
+            "guessPlaceholder": "Your guess",
+            "submitGuessButtonLabel": "Submit Guess",
+            historyLabel: "History"
         },
         utils: {
             convertHeader: "Hand Conversion",

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -285,6 +285,10 @@ export const en = {
             minTurns: "Minimum turns before a riichi is declared: ",
             tilesInHand: "Number of tiles in hand: "
         },
+        shanten: {
+            instructions: "Looking to improve your speed at calculating shanten? This tool will help you practice.",
+            shantenLabel: "Shanten:"
+        },
         utils: {
             convertHeader: "Hand Conversion",
             convertButtonLabel: "Convert Hand",

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -290,7 +290,16 @@ export const en = {
             "newHandButtonLabel": "New Hand",
             "guessPlaceholder": "Your guess",
             "submitGuessButtonLabel": "Submit Guess",
-            historyLabel: "History"
+            historyLabel: "History",
+            stats: {
+                buttonLabel: "Statistics",
+                correctGuesses: "Correct Guesses: {{count}} / {{total}} ({{percent}}%)",
+                averageTime: "Average Time: {{time}} seconds",
+                reset: "Reset Stats",
+                confirmation: "Are you sure you want to reset the stats?",
+                yes: "Yes",
+                no: "No",
+            },
         },
         utils: {
             convertHeader: "Hand Conversion",


### PR DESCRIPTION
A part of the strategy in mahjong depends on how far away you are from a ready hand. For some, this may come naturally, for others (myself included), this can be time consuming.

This pull request introduces a shanten calculator, which gives you the ability to practice this. It includes 3 settings:
- Use timer
- Show index tiles
- Show hand in history

It will then continuously generate a new hand and ask for you to submit a guess. These will be tracked in a _history_ section below, and in _statistics_ above if you want to see the % you got right, and your average time.

## How to test
- [x] Submitting a guess shows up in the history.
- [x] Statistics increment by 1 with each guess. Time gets calculated properly
- [x] A correct guess shows up with a green background.
- [x] An incorrect guess shows up with a red background.

_Video showing the above_

https://github.com/user-attachments/assets/fee67f9d-8ae9-4d3e-a810-bdd234b3d096

- [x] Clicking show index tiles toggles the index tiles on and off.
- [x] Clicking show hand in history toggles the hand on and off.

https://github.com/user-attachments/assets/285990b0-60cc-40e3-805c-ff7278a7e76b

_ Using a timer_

https://github.com/user-attachments/assets/afd47e22-5a68-454a-a716-411faeee54a1

- [x] Clicking "new hand" works

https://github.com/user-attachments/assets/53b4756e-e5b2-437b-aa00-863c4a0d82ac
