### PR TITLE
[BUGFIX] Fix folding timer

### DIFF
--- a/src/states/DefenseState.js
+++ b/src/states/DefenseState.js
@@ -475,16 +475,18 @@ class DefenseState extends React.Component {
             draw = removeRandomItem(tilePool);
             players[0].hand[draw]++;
 
-            this.timer = setTimeout(
-                () => {
-                    this.onTileClicked({target:{name:this.state.lastDraw}});
-                    this.setState({
-                        currentBonus: 0
-                    });
-                },
-                (this.state.settings.time + this.state.currentBonus) * 1000
-            );
-            this.timerUpdate = setInterval(this.updateTime, 100);
+            if (this.state.settings.useTimer) {
+                this.timer = setTimeout(
+                    () => {
+                        this.onTileClicked({target:{name:this.state.lastDraw}});
+                        this.setState({
+                            currentBonus: 0
+                        });
+                    },
+                    (this.state.settings.time + this.state.currentBonus) * 1000
+                );
+                this.timerUpdate = setInterval(this.updateTime, 100);
+            }
         }
 
         let bestSafety = Math.max(...averageSafety);

--- a/src/states/DefenseState.js
+++ b/src/states/DefenseState.js
@@ -65,17 +65,6 @@ class DefenseState extends React.Component {
                 clearTimeout(this.timer);
                 clearInterval(this.timerUpdate);
             }
-        } else {
-            this.timer = setTimeout(
-                () => {
-                    this.onTileClicked({target:{name:this.state.lastDraw}});
-                    this.setState({
-                        currentBonus: 0
-                    });
-                },
-                (this.state.settings.time + this.state.settings.extraTime + 2) * 1000
-            );
-            this.timerUpdate = setInterval(this.updateTime, 100);
         }
 
         this.setState({

--- a/src/states/DefenseState.js
+++ b/src/states/DefenseState.js
@@ -248,7 +248,7 @@ class DefenseState extends React.Component {
             dora: dora,
             lastDraw: shuffle.pop(),
             isComplete: false,
-            currentTime: this.state.settings.time + 2,
+            currentTime: this.state.settings.time,
             currentBonus: this.state.settings.extraTime
         });
 
@@ -257,10 +257,11 @@ class DefenseState extends React.Component {
                 () => {
                     this.onTileClicked({target:{name:this.state.lastDraw}});
                     this.setState({
+
                         currentBonus: 0
                     });
                 },
-                (this.state.settings.time + this.state.settings.extraTime + 2) * 1000
+                (this.state.settings.time + this.state.settings.extraTime) * 1000
             );
             this.timerUpdate = setInterval(this.updateTime, 100);
         }


### PR DESCRIPTION
In https://github.com/Euophrys/Riichi-Trainer/pull/83, I seem to have accidentally enabled the folding timer always after clicking on a tile. My apologies.

This pull request does three things:
- After clicking a tile, it only applies a timer if it was selected
- When setting the time, it removes the 2s bonus to ensure the actual timer & label match
- It no longer auto starts the timer when changing settings to match the behaviour of the Ukeire quiz. This because the actual timer & labels were mismatched for the first go around, which is unnecessarily confusing.

## How to test
- [x] Set the timer. See that the time doesn't move until you click a tile.

https://github.com/user-attachments/assets/51fa808c-5f00-436c-b628-3e5047671f80

- [x] Click a tile when the timer is selected. See the timer count down. When it hits 0, see the tile get discarded.

https://github.com/user-attachments/assets/1813bc43-96d8-4aa3-8232-f5baedfd8026

- [x] Uncheck the timer. Click a tile. Wait long enough to show that the timer is no longer being applied.

https://github.com/user-attachments/assets/ca42870c-f235-4a56-81d2-bc306b5506b2
